### PR TITLE
Add support for AES-192-CBC and AES-256-CBC

### DIFF
--- a/lib/openssl/ccm.rb
+++ b/lib/openssl/ccm.rb
@@ -21,7 +21,8 @@ module OpenSSL
     #
     # @return [[String]] supported algorithms
     def self.ciphers
-      l = OpenSSL::Cipher.ciphers.keep_if { |c| c.end_with?('-128-CBC') }
+      l = OpenSSL::Cipher.ciphers.keep_if { |c| c.end_with?('-128-CBC') or
+        c.end_with?('-192-CBC') or c.end_with?('-256-CBC') }
       l.length.times { |i| l[i] = l[i][0..-9] }
       l
     end
@@ -45,7 +46,15 @@ module OpenSSL
         fail CCMError, 'invalid mac length'
       end
 
-      @cipher = OpenSSL::Cipher.new("#{cipher}-128-CBC")
+      if key.length < 24
+        cipher_key_size = "128"
+      elsif key.length < 32
+        cipher_key_size = "192"
+      else
+        cipher_key_size = "256"
+      end
+
+      @cipher = OpenSSL::Cipher.new("#{cipher}-" + cipher_key_size  + "-CBC")
       @key = key
       @mac_len = mac_len
     end

--- a/test/test_ccm.rb
+++ b/test/test_ccm.rb
@@ -296,4 +296,44 @@ class CCMTest < Test::Unit::TestCase
       end
     end
   end
+
+  #Test case from https://github.com/weidai11/cryptopp/blob/master/TestVectors/ccm.txt
+  def test_aes_data_256
+    key =  %W(
+      0000000000000000000000000000000000000000000000000000000000000000
+      fb7615b23d80891dd470980bc79584c8b2fb64ce60978f4d17fce45a49e830b7
+    )
+
+    nonce = %W(
+      000000000000000000000000
+      dbd1a3636024b7b402da7d6f
+    )
+
+    plaintext = %W(
+      00000000000000000000000000000000
+      a845348ec8c5b5f126f50e76fefd1b1e
+    )
+
+    ciphertext = %W(
+      c1944044c8e7aa95d2de9513c7f3dd8c
+      cc881261c6a7fa72b96a1739176b277f
+    )
+
+    mac = %W(
+      4b0a3e5e51f151eb0ffae7c43d010fdb
+      3472e1145f2c0cbe146349062cf0e423
+    )
+
+    assert(OpenSSL::CCM.ciphers.include?('AES'), 'Missing AES-Cipher')
+    key.length.times do |i|
+      mac_len = mac[i].length / 2
+      ccm = OpenSSL::CCM.new('AES', [key[i]].pack('H*'), mac_len)
+      c = ccm.encrypt([plaintext[i]].pack('H*'), [nonce[i]].pack('H*'))
+      c_unpack = c.unpack('H*')
+      assert_equal([mac[i]], c[-mac_len..-1].unpack('H*'),
+                         "Wrong MAC ENCRYPT in Test #{i} ")
+      assert_equal([ciphertext[i]], c[0..-mac_len - 1].unpack('H*'),
+                         "Wrong ciphertext ENCRYPT in Test #{i}")
+    end
+  end
 end


### PR DESCRIPTION
CCM must be used with 128 bits block and is restricted to
crypto algorithm who use 128 bits key.
AES-256-CBC for example also used 128 bits block but 256 bits key