### PR TITLE
Update cipher validation to be case-insensitive

### DIFF
--- a/lib/openssl/ccm.rb
+++ b/lib/openssl/ccm.rb
@@ -21,10 +21,7 @@ module OpenSSL
     #
     # @return [[String]] supported algorithms
     def self.ciphers
-      l = OpenSSL::Cipher.ciphers.keep_if { |c| c.end_with?('-128-CBC') or
-        c.end_with?('-192-CBC') or c.end_with?('-256-CBC') }
-      l.length.times { |i| l[i] = l[i][0..-9] }
-      l
+      @ciphers ||= OpenSSL::Cipher.ciphers.select { |c| c.match(/-(128|192|256)-CBC$/i) }.map { |e| e[0..-9].upcase }.uniq
     end
 
     public
@@ -38,7 +35,7 @@ module OpenSSL
     #
     # @return [Object] the new CCM object
     def initialize(cipher, key, mac_len)
-      unless CCM.ciphers.include?(cipher)
+      unless CCM.ciphers.include?(cipher.upcase)
         fail CCMError, "unsupported cipher algorithm (#{cipher})"
       end
       fail CCMError, 'invalid key length' unless key.b.length >= 16


### PR DESCRIPTION
I'm facing the following error when using the gem on CircleCI:

    OpenSSL::CCMError:
      unsupported cipher algorithm (AES)
    ./vendor/bundle/ruby/2.5.0/gems/openssl-ccm-1.2.1/lib/openssl/ccm.rb:42:in `initialize'
    ./vendor/bundle/ruby/2.5.0/gems/adyen-cse-ruby-1.1.0/lib/adyen_cse/encrypter.rb:34:in `new'
    ./vendor/bundle/ruby/2.5.0/gems/adyen-cse-ruby-1.1.0/lib/adyen_cse/encrypter.rb:34:in `encrypt!'

The error is weird bcos AES should be supported. It is triggered by:

```ruby
# ./lib/openssl/ccm.rb

def initialize(cipher, key, mac_len)
  unless CCM.ciphers.include?(cipher)
    fail CCMError, "unsupported cipher algorithm (#{cipher})"
  end
  ...
end
```

SSH-ing into the machine, I find that `OpenSSL::CCM.ciphers` yields an empty array, which explains why the exception is raised.

Due to some odd reason (which I'm still unsure of the cause), `OpenSSL::Cipher.ciphers` are returned as lowercased strings in my CircleCI environment:

    irb(main)> OpenSSL::Cipher.ciphers
    => ["aes-128-cbc", "aes-128-cbc-hmac-sha1", "aes-128-cbc-hmac-sha256", "aes-128-ccm", ...]

    $ openssl version
    OpenSSL 1.1.0j  20 Nov 2018

However, in my local machine, ciphers are returned as uppercased strings:

    irb(main)> OpenSSL::Cipher.ciphers
    => ["AES-128-CBC", "AES-128-CBC-HMAC-SHA1", "AES-128-CFB", "AES-128-CFB1", "AES-128-CFB8", ...]

    $ openssl version
    LibreSSL 2.6.5

---

So, I refactored the `def self.ciphers` method to perform a case-insensitive check instead, and added memoization.